### PR TITLE
Añadiendo Métodos para Filtrar Registros por Estado

### DIFF
--- a/Controllers/ProyectosController.cs
+++ b/Controllers/ProyectosController.cs
@@ -52,6 +52,54 @@ namespace TechOil.Controllers
         }
 
         /// <summary>
+        /// Devuelve todos los proyectos en estado terminado
+        /// </summary>
+        /// <returns>Retorna todos los proyectos terminado</returns>
+
+        [HttpGet("terminado")]
+        [AllowAnonymous]
+        public async Task<ActionResult<IEnumerable<Proyecto>>> GetAllTerminado()
+        {
+            var proyectos = await _unitOfWork.ProyectoRepository.GetAllTerminado();
+            if (proyectos is null)
+            {
+                return ResponseFactory.CreateErrorResponseR(403, "Error recurso no encontrado");                
+            }
+            else
+            {
+                return ResponseFactory.CreateSuccessResponseR(200, proyectos);
+            }
+            
+        }
+
+        /// <summary>
+        /// Devuelve todos los proyectos en estado confirmado
+        /// </summary>
+        /// <returns>Retorna todos los proyectos confirmados</returns>
+
+        [HttpGet("confirmado")]
+        [AllowAnonymous]
+        public async Task<ActionResult<IEnumerable<Proyecto>>> GetAllConfirmado()
+        {
+            var proyectos = await _unitOfWork.ProyectoRepository.GetAllConfirmado();
+            return Ok(proyectos);
+        }
+
+
+        /// <summary>
+        /// Devuelve todos los proyectos en estado pendiente
+        /// </summary>
+        /// <returns>Retorna todos los proyectos pendientes</returns>
+
+        [HttpGet("pendiente")]
+        [AllowAnonymous]
+        public async Task<ActionResult<IEnumerable<Proyecto>>> GetAllPendiente()
+        {
+            var proyectos = await _unitOfWork.ProyectoRepository.GetAllPendiente();
+            return Ok(proyectos);
+        }
+
+        /// <summary>
         /// Registra el proyecto
         /// </summary>
         /// <param name="dto"></param>

--- a/DataAccess/Repositories/Interfaces/IRepository.cs
+++ b/DataAccess/Repositories/Interfaces/IRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using TechOil.Entities;
 
 namespace TechOil.DataAccess.Repositories.Interfaces
 {
@@ -6,9 +7,11 @@ namespace TechOil.DataAccess.Repositories.Interfaces
     {
         public Task<List<T>> GetAll();
         public Task<List<T>> GetAllActivo();
+        public Task<List<T>> GetAllTerminado();
+        public Task<List<T>> GetAllConfirmado();
+        public Task<List<Proyecto>> GetAllPendiente();
         public Task<T> GetById(int id);
         public Task<bool> Insert(T entity);
-
         public Task<bool> Update(T entity);
         public Task<bool> Delete(int id);        
     }

--- a/DataAccess/Repositories/ProyectoRepository.cs
+++ b/DataAccess/Repositories/ProyectoRepository.cs
@@ -11,6 +11,20 @@ namespace TechOil.DataAccess.Repositories
             
         }
 
+        public virtual async Task<List<Proyecto>> GetAllTerminado()
+        {
+            return await _context.Proyectos.Where(s => s.EstadoProyecto == EstadoProyecto.Terminado).ToListAsync();
+        }
+              
+        public virtual async Task<List<Proyecto>> GetAllConfirmado()
+        {
+            return await _context.Proyectos.Where(s => s.EstadoProyecto == EstadoProyecto.Confirmado).ToListAsync();
+        }        
+        public virtual async Task<List<Proyecto>> GetAllPendiente()
+        {
+            return await _context.Proyectos.Where(s => s.EstadoProyecto == EstadoProyecto.Pendiente).ToListAsync();
+        }
+
         public override async Task<bool> Update(Proyecto updateProyecto)
         {
             var proyecto = await _context.Proyectos.FirstOrDefaultAsync(x => x.CodProyecto == updateProyecto.CodProyecto);

--- a/DataAccess/Repositories/Repository.cs
+++ b/DataAccess/Repositories/Repository.cs
@@ -45,5 +45,20 @@ namespace TechOil.DataAccess.Repositories
             return await _context.Set<T>().FindAsync(id);
             
         }
+
+        public Task<List<T>> GetAllTerminado()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<List<T>> GetAllConfirmado()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<List<Proyecto>> GetAllPendiente()
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
**Descripción del Pull Request:**
Este pull request introduce mejoras significativas en nuestra API al agregar tres nuevos métodos de consulta que permiten filtrar registros por estado: `GetAllTerminado`, `GetAllPendiente` y `GetAllConfirmado`. Estos métodos proporcionarán a los usuarios la capacidad de recuperar registros específicos según sus estados actuales, lo que mejorará la funcionalidad y la usabilidad de nuestra aplicación.

Detalles de los Cambios:
- Se han implementado los métodos `GetAllTerminado`, `GetAllPendiente` y `GetAllConfirmado` en los controladores correspondientes.
- Cada implementación cumple con las mejores prácticas de codificación y utiliza la estructura existente de nuestros métodos de consulta.

Estos nuevos métodos mejorarán significativamente la capacidad de nuestros usuarios para acceder y trabajar con registros en función de su estado actual. Agradecemos sus comentarios y sugerencias para seguir mejorando nuestra API.

¡Gracias por su colaboración en este avance importante!